### PR TITLE
fix crash when float rotation

### DIFF
--- a/eagle2svg/eagle_element.py
+++ b/eagle2svg/eagle_element.py
@@ -276,9 +276,9 @@ class Label(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
 
     def render(self,
                view_box=None,
@@ -341,9 +341,9 @@ class Pad(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
 
     def render(self,
                x=0.0,
@@ -626,9 +626,9 @@ class Text(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
 
     def render(self,
                x=0.0,
@@ -678,9 +678,9 @@ class Pin(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
 
     def render(self,
                x=0.0,
@@ -1106,9 +1106,9 @@ class Element(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
         if '@smashed' in data:
             if data['@smashed'] == 'yes':
                 self.smashed = True
@@ -1151,9 +1151,9 @@ class Instance(object):
             if data['@rot'][0] == 'M':
                 self.mirror = True
                 if data['@rot'][1] == 'R':
-                    self.rot = int(data['@rot'][2:])
+                    self.rot = float(data['@rot'][2:])
             elif data['@rot'][0] == 'R':
-                self.rot = int(data['@rot'][1:])
+                self.rot = float(data['@rot'][1:])
         if '@smashed' in data:
             if data['@smashed'] == 'yes':
                 self.smashed = True


### PR DESCRIPTION
Hi, when i tried to render a board i made a few years back, i got the following error:

```Traceback (most recent call last):
  File "/home/vandi/code/eagle2svg/venv/bin/eagle2svg", line 8, in <module>
    sys.exit(render_main())
             ^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/render.py", line 17, in render_main
    data = eagle_parser.Eagle(argv[1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_parser.py", line 133, in __init__
    self.data = Board(data['eagle']['drawing']['board'])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_parser.py", line 22, in __init__
    super(Board, self).__init__(data)
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_parser.py", line 13, in __init__
    library = eagle_element.Library(library_data)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_element.py", line 1074, in __init__
    package = Package(package_data)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_element.py", line 994, in __init__
    super(Package, self).__init__(data)
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_element.py", line 881, in __init__
    self.texts.append(Text(text_data))
                      ^^^^^^^^^^^^^^^
  File "/home/vandi/code/eagle2svg/eagle2svg/eagle_element.py", line 631, in __init__
    self.rot = int(data['@rot'][1:])
               ^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '226.6'```

The board contained a stm32 footprint with a text that was rotated by 226.6 degrees, which caused the crash because the code did not support decimal rotations. This pull request fixes the issue.